### PR TITLE
Search for libssl-1.0.0 first

### DIFF
--- a/lib/btcruby/openssl.rb
+++ b/lib/btcruby/openssl.rb
@@ -10,7 +10,7 @@ module BTC
     if FFI::Platform.windows?
       ffi_lib 'libeay32', 'ssleay32'
     else
-      ffi_lib 'ssl'
+      ffi_lib ['libssl.so.1.0.0', 'ssl']
     end
 
     NID_secp256k1 = 714


### PR DESCRIPTION
Because on systems with libssl-1.1+ ruby 2.3 and less won't work properly. libssl-1.0 should be manually installed and imported.