### PR TITLE
Add pry-byebug in test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec
 gem 'rake'
 group :development, :test do
   gem 'minitest'
+  gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (10.0.2)
+    coderay (1.1.2)
     ffi (1.9.18)
+    method_source (0.9.0)
     minitest (5.10.2)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (10.3.2)
 
 PLATFORMS
@@ -17,6 +26,7 @@ PLATFORMS
 DEPENDENCIES
   btcruby!
   minitest
+  pry-byebug
   rake
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'minitest/spec'
 require 'minitest/autorun'
+require 'pry-byebug'
 
 require_relative '../lib/btcruby'
 require_relative '../lib/btcruby/extensions'


### PR DESCRIPTION
Allow developers to debug with pry without having to install the gem and require it. It is not in the gemspec because it's not a development dependency.